### PR TITLE
Enable a full class transform for OneHotEncoder

### DIFF
--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -178,8 +178,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         else:
             return X.values
 
-    @staticmethod
-    def get_dummies(X_in, cols=None):
+    def get_dummies(self, X_in, cols=None):
         """
         """
 
@@ -193,8 +192,11 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
         bin_cols = []
         for col in cols:
-            classes = [x for x in set(X[col].values.tolist()) if np.isfinite(x)]
-            for class_ in classes:
+            col_tuples = [class_map['mapping'] for class_map in self.ordinal_encoder.mapping if class_map['col'] == col][0]
+            fit_classes = [col_val[1] for col_val in col_tuples]
+            if self.handle_unknown == 'impute':
+                fit_classes.append(-1)
+            for class_ in fit_classes:
                 n_col_name = str(col) + '_%s' % (class_, )
                 X[n_col_name] = X[col] == class_
                 bin_cols.append(n_col_name)

--- a/category_encoders/tests/test_encoders.py
+++ b/category_encoders/tests/test_encoders.py
@@ -427,6 +427,10 @@ class TestEncoders(unittest.TestCase):
         enc.fit(X, None)
         self.assertTrue(isinstance(enc.transform(X_t), np.ndarray))
 
+        enc = encoders.OneHotEncoder(verbose=1, return_df=False)
+        enc.fit(X, None)
+        self.assertTrue(enc.transform(X_t[X_t['D'] != 'A']).shape[1] == 19)
+
         enc = encoders.OneHotEncoder(verbose=1, return_df=True, impute_missing=True, handle_unknown='impute')
         enc.fit(X, None)
         out = enc.transform(X_t_extra)


### PR DESCRIPTION
@wdm0006 PR to address https://github.com/scikit-learn-contrib/categorical-encoding/issues/19

Have `OneHotEncoder` expand all the classes/categories that were `fit`, instead of just the classes that were passed in to `transform`.