### PR TITLE
consistent ordering for categories

### DIFF
--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -219,8 +219,7 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
                     X[switch.get('col')] = X[switch.get('col')].astype(float).reshape(-1, )
         else:
             for col in cols:
-                categories = list(set(X[col].values))
-                random.shuffle(categories)
+                categories = pd.unique(X[col].values)
 
                 X[str(col) + '_tmp'] = np.nan
                 for idx, val in enumerate(categories):


### PR DESCRIPTION
it seems better to use the pandas ordering of `Uniques are returned in order of appearance` https://pandas.pydata.org/pandas-docs/stable/generated/pandas.unique.html#pandas.unique rather than something random. This way the models are reproducible 