### PR TITLE
optimizing ordinal_encoding

### DIFF
--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -247,9 +247,8 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
         if mapping is not None:
             mapping_out = mapping
             for switch in mapping:
-                X[str(switch.get('col')) + '_tmp'] = np.nan
-                for category in switch.get('mapping'):
-                    X.loc[X[switch.get('col')] == category[0], str(switch.get('col')) + '_tmp'] = str(category[1])
+                categories_dict = dict(switch.get('mapping'))
+                X[str(switch.get('col')) + '_tmp'] = X[switch.get('col')].map(lambda x: categories_dict.get(x))
                 del X[switch.get('col')]
                 X.rename(columns={str(switch.get('col')) + '_tmp': switch.get('col')}, inplace=True)
 
@@ -268,10 +267,8 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
             mapping_out = []
             for col in cols:
                 categories = [x for x in pd.unique(X[col].values) if x is not None]
-
-                X[str(col) + '_tmp'] = np.nan
-                for idx, val in enumerate(categories):
-                    X.loc[X[col] == val, str(col) + '_tmp'] = str(idx)
+                categories_dict = {x:i for i,x in enumerate(categories)}
+                X[str(col) + '_tmp'] = X[col].map(lambda x: categories_dict.get(x))
                 del X[col]
                 X.rename(columns={str(col) + '_tmp': col}, inplace=True)
 


### PR DESCRIPTION
I've added an optimization to `OrdinalEncoder.ordinal_encoding`. When the number of categories is large, `OrdinalEncoder` (and also other encoders using `OrdinalEncoder`) is very slow because of the for loops and `pandas.DataFrame.iloc`. So, for loops in `ordinal_encoding` are removed and replaced by using `pandas.Series.map`. 

All `nosetests --with-coverage` tests has been passed.

Any comment is warmly welcome. Here is my benchmarks.

```py
# on master branch 
In [1]: import category_encoders as ce

In [2]: %%time
   ...: many_categories_list = ["category_{}".format(i) for i in range(10000)]
   ...: encoder = ce.OrdinalEncoder()
   ...: encoder.fit(many_categories_list)
   ...: encoder.transform(many_categories_list)
   ...:
CPU times: user 1min 8s, sys: 835 ms, total: 1min 9s
Wall time: 1min 11s
```

```python
# on this branch
In [1]: import category_encoders as pr

In [2]: %%time
   ...: many_categories_list = ["category_{}".format(i) for i in range(10000)]
   ...: encoder = pr.OrdinalEncoder()
   ...: encoder.fit(many_categories_list)
   ...: encoder.transform(many_categories_list)
   ...:
CPU times: user 31.9 ms, sys: 3.47 ms, total: 35.4 ms
Wall time: 34.3 ms
```
