### PR TITLE
Add support for pandas categorical types when using OrdinalEncoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *,cover

--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -266,8 +266,12 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
         else:
             mapping_out = []
             for col in cols:
-                categories = [x for x in pd.unique(X[col].values) if x is not None]
-                categories_dict = {x: i + 1 for i, x in enumerate(categories)}
+                if X[col].dtype.name == 'category':
+                    categories = X[col].cat.categories
+                    categories_dict = {x: i for i, x in enumerate(categories)}
+                else:
+                    categories = [x for x in pd.unique(X[col].values) if x is not None]
+                    categories_dict = {x: i + 1 for i, x in enumerate(categories)}
                 X[str(col) + '_tmp'] = X[col].map(lambda x: categories_dict.get(x))
                 del X[col]
                 X.rename(columns={str(col) + '_tmp': col}, inplace=True)
@@ -281,6 +285,6 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
                 except ValueError as e:
                     X[col] = X[col].astype(float).values.reshape(-1, )
 
-                mapping_out.append({'col': col, 'mapping': [(x[1], x[0] + 1) for x in list(enumerate(categories))]}, )
+                mapping_out.append({'col': col, 'mapping': [(cat, code) for cat, code in categories_dict.items()]})
 
         return X, mapping_out

--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -30,3 +30,9 @@ def convert_input(X):
         X = X.apply(lambda x: pd.to_numeric(x, errors='ignore'))
 
     return X
+
+
+def get_mapping_for_col(category_mapping, col):
+    for column_mapping in category_mapping:
+        if column_mapping['col'] == col:
+            return column_mapping['mapping']


### PR DESCRIPTION
Addresses issue #70 

If a column is a pandas categorical dtype and no custom mapping is provided, use the mapping from the pandas categorical.

Added a test that passes when run locally.

Some specific questions I'd appreciate guidance on:
- I added a method `get_mapping_for_col` to utils.py. I'm not sure that the names I used are in line with the project.
- Pandas categoricals will usually fail if impute_missing=True is passed (the default) since it tries a fillna(0) which doesn't always make sense for a pandas categorical.  I didn't touch this, but maybe it deserves special handling.
- Any implementation suggestions?

thanks,
Dennis