### PR TITLE
Fix patsy naming issue

### DIFF
--- a/category_encoders/backward_difference.py
+++ b/category_encoders/backward_difference.py
@@ -203,7 +203,7 @@ class BackwardDifferenceEncoder(BaseEstimator, TransformerMixin):
 
         bin_cols = []
         for col in cols:
-            mod = dmatrix("C(%s, Diff)" % (col, ), X)
+            mod = dmatrix("C(Q(\"%s\"), Diff)" % (col, ), X)
             for dig in range(len(mod[0])):
                 X[str(col) + '_%d' % (dig, )] = mod[:, dig]
                 bin_cols.append(str(col) + '_%d' % (dig, ))

--- a/category_encoders/helmert.py
+++ b/category_encoders/helmert.py
@@ -199,7 +199,7 @@ class HelmertEncoder(BaseEstimator, TransformerMixin):
 
         bin_cols = []
         for col in cols:
-            mod = dmatrix("C(%s, Helmert)" % (col, ), X)
+            mod = dmatrix("C(Q(\"%s\"), Helmert)" % (col, ), X)
             for dig in range(len(mod[0])):
                 X[str(col) + '_%d' % (dig, )] = mod[:, dig]
                 bin_cols.append(str(col) + '_%d' % (dig, ))

--- a/category_encoders/polynomial.py
+++ b/category_encoders/polynomial.py
@@ -202,7 +202,7 @@ class PolynomialEncoder(BaseEstimator, TransformerMixin):
 
         bin_cols = []
         for col in cols:
-            mod = dmatrix("C(%s, Poly)" % (col, ), X)
+            mod = dmatrix("C(Q(\"%s\"), Poly)" % (col, ), X)
             for dig in range(len(mod[0])):
                 X[str(col) + '_%d' % (dig, )] = mod[:, dig]
                 bin_cols.append(str(col) + '_%d' % (dig, ))

--- a/category_encoders/sum_coding.py
+++ b/category_encoders/sum_coding.py
@@ -201,7 +201,7 @@ class SumEncoder(BaseEstimator, TransformerMixin):
 
         bin_cols = []
         for col in cols:
-            mod = dmatrix("C(%s, Sum)" % (col, ), X)
+            mod = dmatrix("C(Q(\"%s\"), Sum)" % (col, ), X)
             for dig in range(len(mod[0])):
                 X[str(col) + '_%d' % (dig, )] = mod[:, dig]
                 bin_cols.append(str(col) + '_%d' % (dig, ))


### PR DESCRIPTION
Columns named with awkward names including restricted characters such as "-" (dashes) will get evaluated to minus signs through patsy which requires their wrapping using the Q builtin.
http://patsy.readthedocs.io/en/latest/builtins-reference.html#patsy.builtins.Q

Minimum broken example:
```python
import pandas as pd
import category_encoders as ce
X = pd.DataFrame([1, 2, 3, 4], columns=['test-broken'])
X_trans = ce.HelmertEncoder(cols=['test-broken']).fit_transform(X)
```
Raises the error:
> patsy.PatsyError: Error evaluating factor: NameError: name 'col_test' is not defined
    C(col_test-broken, Helmert)