### PR TITLE
Update target_encoder.py

### DIFF
--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -86,9 +86,9 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         self.impute_missing = impute_missing
         self.handle_unknown = handle_unknown
         self._mean = None
-        
-        
-    
+
+
+
     def fit(self, X, y, **kwargs):
         """Fit encoder according to X and y.
         Parameters
@@ -137,7 +137,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         X : array-like, shape = [n_samples, n_features]
         y : array-like, shape = [n_samples] when transform by leave one out
             None, when transform withour target infor(such as transform test set)
-            
+
         Returns
         -------
         p : array, shape = [n_samples, n_numeric + N]
@@ -162,7 +162,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
             mapping=self.mapping,
             cols=self.cols,
             impute_missing=self.impute_missing,
-            handle_unknown=self.handle_unknown, 
+            handle_unknown=self.handle_unknown,
             min_samples_leaf=self.min_samples_leaf,
             smoothing_in=self.smoothing
         )
@@ -175,25 +175,29 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
             return X
         else:
             return X.values
-    
+
     def target_encode(self, X_in, y, mapping=None, cols=None, impute_missing=True,
-            handle_unknown='impute', min_samples_leaf=1, smoothing_in=1):
+                      handle_unknown='impute', min_samples_leaf=1, smoothing_in=1):
         X = X_in.copy(deep=True)
         if cols is None:
             cols = X.columns.values
-        
+
+        types = X.apply(lambda x: pd.api.types.infer_dtype(x.values))
+        for col in types[types == 'unicode'].index:
+            X[col] = X[col].astype(str)
+
         if mapping is not None:
             mapping_out = mapping
             for switch in mapping:
-                X[str(switch.get('col')) + '_tmp'] = np.nan
+                X[switch.get('col') + '_tmp'] = np.nan
                 for val in switch.get('mapping'):
                     if switch.get('mapping')[val]['count'] == 1:
-                        X.loc[X[switch.get('col')] == val, str(switch.get('col')) + '_tmp'] = self._mean
+                        X.loc[X[switch.get('col')] == val, switch.get('col') + '_tmp'] = self._mean
                     else:
-                        X.loc[X[switch.get('col')] == val, str(switch.get('col')) + '_tmp'] = \
+                        X.loc[X[switch.get('col')] == val, switch.get('col') + '_tmp'] = \
                             switch.get('mapping')[val]['smoothing']
                 del X[switch.get('col')]
-                X.rename(columns={str(switch.get('col')) + '_tmp': switch.get('col')}, inplace=True)
+                X.rename(columns={switch.get('col') + '_tmp': switch.get('col')}, inplace=True)
 
                 if impute_missing:
                     if handle_unknown == 'impute':
@@ -203,7 +207,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
                             raise ValueError('Unexpected categories found in %s' % (switch.get('col'),))
 
                 X[switch.get('col')] = X[switch.get('col')].astype(float).values.reshape(-1, )
-        
+
         else:
             self._mean = y.mean()
             prior = self._mean
@@ -213,19 +217,19 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
                 tmp['mean'] = tmp['sum'] / tmp['count']
                 tmp = tmp.to_dict(orient='index')
 
-                X[str(col) + '_tmp'] = np.nan
+                X[col + '_tmp'] = np.nan
                 for val in tmp:
                     tmp[val]['mean'] = tmp[val]['sum']/tmp[val]['count']
                     if tmp[val]['count'] == 1:
-                        X.loc[X[col] == val, str(col) + '_tmp'] = self._mean
+                        X.loc[X[col] == val, col + '_tmp'] = self._mean
                     else:
                         smoothing = smoothing_in
                         smoothing = 1 / (1 + np.exp(-(tmp[val]["count"] - min_samples_leaf) / smoothing))
                         cust_smoothing = prior * (1 - smoothing) + tmp[val]['mean'] * smoothing
-                        X.loc[X[col] == val, str(col) + '_tmp'] = cust_smoothing
+                        X.loc[X[col] == val, col + '_tmp'] = cust_smoothing
                         tmp[val]['smoothing'] = cust_smoothing
                 del X[col]
-                X.rename(columns={str(col) + '_tmp': col}, inplace=True)
+                X.rename(columns={col + '_tmp': col}, inplace=True)
                 if impute_missing:
                     if handle_unknown == 'impute':
                         X[col].fillna(self._mean, inplace=True)


### PR DESCRIPTION
Casting to string can cause errors, especially with unicodes and python 2.7. 
Therefore I suggest not casting to strings unless the type is not unicode and not type string. 

The reason I suggest this file change is because you may have a column name such as `régions`. 
Using the `str(col)` would cause an ascii error. 
Using my proposed not cast this column value. It would only cast if needed.