### PR TITLE
in the fit call of the target encoder be sure to also pass min_sample…

### DIFF
--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -119,7 +119,9 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
             mapping=self.mapping,
             cols=self.cols,
             impute_missing=self.impute_missing,
-            handle_unknown=self.handle_unknown
+            handle_unknown=self.handle_unknown,
+            smoothing_in=self.smoothing,
+            min_samples_leaf=self.min_samples_leaf
         )
         self.mapping = categories
 
@@ -163,8 +165,6 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
             cols=self.cols,
             impute_missing=self.impute_missing,
             handle_unknown=self.handle_unknown, 
-            min_samples_leaf=self.min_samples_leaf,
-            smoothing_in=self.smoothing
         )
 
         if self.drop_invariant:

--- a/category_encoders/tests/test_encoders.py
+++ b/category_encoders/tests/test_encoders.py
@@ -3,6 +3,7 @@ import random
 import pandas as pd
 import category_encoders as encoders
 import numpy as np
+import numpy.testing as npt
 
 __author__ = 'willmcginnis'
 
@@ -627,3 +628,42 @@ class TestEncoders(unittest.TestCase):
         enc.fit(X, y)
         self.verify_numeric(enc.transform(X_t))
         self.verify_numeric(enc.transform(X_t, y_t))
+
+    def test_fit_HaveConstructorSetSmoothingAndMinSamplesLeaf_ExpectUsedInFit(self):
+        """
+
+        :return:
+        """
+        k = 2
+        f = 10
+        binary_cat_example = pd.DataFrame(
+            {'Trend': ['UP', 'UP', 'DOWN', 'FLAT', 'DOWN', 'UP', 'DOWN', 'FLAT', 'FLAT', 'FLAT'],
+             'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
+        encoder = encoders.TargetEncoder(cols=['Trend'], min_samples_leaf=k, smoothing=f)
+
+        encoder.fit(binary_cat_example, binary_cat_example['target'])
+        trend_mapping = encoder.mapping[0]['mapping']
+
+        npt.assert_almost_equal(0.4125, trend_mapping['DOWN']['smoothing'], 4)
+        npt.assert_almost_equal(.5, trend_mapping['FLAT']['smoothing'], 0)
+        npt.assert_almost_equal(0.5874, trend_mapping['UP']['smoothing'], 4)
+
+    def test_fit_transform_HaveConstructorSetSmoothingAndMinSamplesLeaf_ExpectCorrectValueInResult(self):
+        """
+
+        :return:
+        """
+        k = 2
+        f = 10
+        binary_cat_example = pd.DataFrame(
+            {'Trend': ['UP', 'UP', 'DOWN', 'FLAT', 'DOWN', 'UP', 'DOWN', 'FLAT', 'FLAT', 'FLAT'],
+             'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
+        encoder = encoders.TargetEncoder(cols=['Trend'], min_samples_leaf=k, smoothing=f)
+
+        result = encoder.fit_transform(binary_cat_example, binary_cat_example['target'])
+        values = result['Trend'].values
+
+        npt.assert_almost_equal(0.5874, values[0], 4)
+        npt.assert_almost_equal(0.5874, values[1], 4)
+        npt.assert_almost_equal(0.4125, values[2], 4)
+        npt.assert_almost_equal(0.5, values[3], 0)


### PR DESCRIPTION
Merge request to deal with issue raised in 

https://github.com/scikit-learn-contrib/categorical-encoding/issues/109

I added two two tests to check the fit and transform methods to ensure that when fit is called the `min_samples_leaf` and `smoothing` are used in fit and those results are applied in transform.
