### PR TITLE
Issue 109 smoothing min sample

### DIFF
--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -119,7 +119,9 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
             mapping=self.mapping,
             cols=self.cols,
             impute_missing=self.impute_missing,
-            handle_unknown=self.handle_unknown
+            handle_unknown=self.handle_unknown,
+            smoothing_in=self.smoothing,
+            min_samples_leaf=self.min_samples_leaf
         )
         self.mapping = categories
 
@@ -163,8 +165,6 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
             cols=self.cols,
             impute_missing=self.impute_missing,
             handle_unknown=self.handle_unknown, 
-            min_samples_leaf=self.min_samples_leaf,
-            smoothing_in=self.smoothing
         )
 
         if self.drop_invariant:

--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -215,11 +215,11 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
 
                 X[str(col) + '_tmp'] = np.nan
                 for val in tmp:
-                    tmp[val]['mean'] = tmp[val]['sum']/tmp[val]['count']
                     if tmp[val]['count'] == 1:
                         X.loc[X[col] == val, str(col) + '_tmp'] = self._mean
                     else:
-                        smoothing = smoothing_in
+                        # Make smoothing a float so that python 2 does not treat as integer division
+                        smoothing = float(smoothing_in)
                         smoothing = 1 / (1 + np.exp(-(tmp[val]["count"] - min_samples_leaf) / smoothing))
                         cust_smoothing = prior * (1 - smoothing) + tmp[val]['mean'] * smoothing
                         X.loc[X[col] == val, str(col) + '_tmp'] = cust_smoothing

--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -80,7 +80,8 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         self.verbose = verbose
         self.cols = cols
         self.min_samples_leaf = min_samples_leaf
-        self.smoothing = smoothing
+        # Make smoothing a float so that python 2 does not treat as integer division
+        self.smoothing = float(smoothing)
         self._dim = None
         self.mapping = None
         self.impute_missing = impute_missing
@@ -218,8 +219,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
                     if tmp[val]['count'] == 1:
                         X.loc[X[col] == val, str(col) + '_tmp'] = self._mean
                     else:
-                        # Make smoothing a float so that python 2 does not treat as integer division
-                        smoothing = float(smoothing_in)
+                        smoothing = smoothing_in
                         smoothing = 1 / (1 + np.exp(-(tmp[val]["count"] - min_samples_leaf) / smoothing))
                         cust_smoothing = prior * (1 - smoothing) + tmp[val]['mean'] * smoothing
                         X.loc[X[col] == val, str(col) + '_tmp'] = cust_smoothing

--- a/category_encoders/tests/test_encoders.py
+++ b/category_encoders/tests/test_encoders.py
@@ -3,7 +3,6 @@ import random
 import pandas as pd
 import category_encoders as encoders
 import numpy as np
-from math import isclose
 
 __author__ = 'willmcginnis'
 
@@ -644,9 +643,9 @@ class TestEncoders(unittest.TestCase):
         encoder.fit(binary_cat_example, binary_cat_example['target'])
         trend_mapping = encoder.mapping[0]['mapping']
 
-        assert isclose(0.4125, trend_mapping['DOWN']['smoothing'], abs_tol=1e-4)
-        assert isclose(.5, trend_mapping['FLAT']['smoothing'], abs_tol=1e-4)
-        assert isclose(0.5874, trend_mapping['UP']['smoothing'], abs_tol=1e-4)
+        self.assertAlmostEquals(0.4125, trend_mapping['DOWN']['smoothing'], delta=1e-4)
+        self.assertEqual(0.5, trend_mapping['FLAT']['smoothing'])
+        self.assertAlmostEquals(0.5874, trend_mapping['UP']['smoothing'], delta=1e-4)
 
     def test_fit_transform_HaveConstructorSetSmoothingAndMinSamplesLeaf_ExpectCorrectValueInResult(self):
         """
@@ -663,7 +662,7 @@ class TestEncoders(unittest.TestCase):
         result = encoder.fit_transform(binary_cat_example, binary_cat_example['target'])
         values = result['Trend'].values
 
-        assert isclose(0.5874, values[0], abs_tol=1e-4)
-        assert isclose(0.5874, values[1], abs_tol=1e-4)
-        assert isclose(0.4125, values[2], abs_tol=1e-4)
-        assert isclose(0.5, values[3], abs_tol=1e-4)
+        self.assertAlmostEquals(0.5874, values[0], delta=1e-4)
+        self.assertAlmostEquals(0.5874, values[1], delta=1e-4)
+        self.assertAlmostEquals(0.4125, values[2], delta=1e-4)
+        self.assertEqual(0.5, values[3])

--- a/category_encoders/tests/test_encoders.py
+++ b/category_encoders/tests/test_encoders.py
@@ -3,6 +3,7 @@ import random
 import pandas as pd
 import category_encoders as encoders
 import numpy as np
+import numpy.testing as npt
 
 __author__ = 'willmcginnis'
 
@@ -627,3 +628,42 @@ class TestEncoders(unittest.TestCase):
         enc.fit(X, y)
         self.verify_numeric(enc.transform(X_t))
         self.verify_numeric(enc.transform(X_t, y_t))
+
+    def test_fit_HaveConstructorSetSmoothingAndMinSamplesLeaf_ExpectUsedInFit(self):
+        """
+
+        :return:
+        """
+        k = 2
+        f = 10
+        binary_cat_example = pd.DataFrame(
+            {'Trend': ['UP', 'UP', 'DOWN', 'FLAT', 'DOWN', 'UP', 'DOWN', 'FLAT', 'FLAT', 'FLAT'],
+             'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
+        encoder = encoders.TargetEncoder(cols=['Trend'], min_samples_leaf=k, smoothing=f)
+
+        encoder.fit(binary_cat_example, binary_cat_example['target'])
+        trend_mapping = encoder.mapping[0]['mapping']
+
+        npt.assert_almost_equal(0.4125, trend_mapping['DOWN']['smoothing'], 4)
+        npt.assert_almost_equal(.5, trend_mapping['FLAT']['smoothing'], 0)
+        npt.assert_almost_equal(0.5874, trend_mapping['UP']['smoothing'], 4)
+
+    def test_fit_transform_HaveConstructorSetSmoothingAndMinSamplesLeaf_ExpectCorrectValueInResult(self):
+        """
+
+        :return:
+        """
+        k = 2
+        f = 10
+        binary_cat_example = pd.DataFrame(
+            {'Trend': ['UP', 'UP', 'DOWN', 'FLAT', 'DOWN', 'UP', 'DOWN', 'FLAT', 'FLAT', 'FLAT'],
+             'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
+        encoder = encoders.TargetEncoder(cols=['Trend'], min_samples_leaf=k, smoothing=f)
+
+        result = encoder.fit_transform(binary_cat_example, binary_cat_example['target'])
+        values = result['Trend'].values
+
+        npt.assert_almost_equal(0.5874, values[0], 4)
+        npt.assert_almost_equal(0.5874, values[1], 4)
+        npt.assert_almost_equal(0.4125, values[2], 4)
+        npt.assert_almost_equal(0.5, values[3], 0)

--- a/category_encoders/tests/test_encoders.py
+++ b/category_encoders/tests/test_encoders.py
@@ -3,7 +3,7 @@ import random
 import pandas as pd
 import category_encoders as encoders
 import numpy as np
-import numpy.testing as npt
+from math import isclose
 
 __author__ = 'willmcginnis'
 
@@ -644,9 +644,9 @@ class TestEncoders(unittest.TestCase):
         encoder.fit(binary_cat_example, binary_cat_example['target'])
         trend_mapping = encoder.mapping[0]['mapping']
 
-        npt.assert_almost_equal(0.4125, trend_mapping['DOWN']['smoothing'], 4)
-        npt.assert_almost_equal(.5, trend_mapping['FLAT']['smoothing'], 0)
-        npt.assert_almost_equal(0.5874, trend_mapping['UP']['smoothing'], 4)
+        assert isclose(0.4125, trend_mapping['DOWN']['smoothing'], abs_tol=1e-4)
+        assert isclose(.5, trend_mapping['FLAT']['smoothing'], abs_tol=1e-4)
+        assert isclose(0.5874, trend_mapping['UP']['smoothing'], abs_tol=1e-4)
 
     def test_fit_transform_HaveConstructorSetSmoothingAndMinSamplesLeaf_ExpectCorrectValueInResult(self):
         """
@@ -663,7 +663,7 @@ class TestEncoders(unittest.TestCase):
         result = encoder.fit_transform(binary_cat_example, binary_cat_example['target'])
         values = result['Trend'].values
 
-        npt.assert_almost_equal(0.5874, values[0], 4)
-        npt.assert_almost_equal(0.5874, values[1], 4)
-        npt.assert_almost_equal(0.4125, values[2], 4)
-        npt.assert_almost_equal(0.5, values[3], 0)
+        assert isclose(0.5874, values[0], abs_tol=1e-4)
+        assert isclose(0.5874, values[1], abs_tol=1e-4)
+        assert isclose(0.4125, values[2], abs_tol=1e-4)
+        assert isclose(0.5, values[3], abs_tol=1e-4)


### PR DESCRIPTION
Here is the PR to address https://github.com/scikit-learn-contrib/categorical-encoding/issues/109

The fix was to pass `smoothing` and `min_samples_leaf` into the `target_encode` function for the fit function. 

I had some trouble finding test methods that worked for python3 and 2. 

I also found an issue where the calculation in python 2 was incorrect because the `-(n-k)/f` division was integer division leaving off the decimal. So I cast the smoothing to a float which fixed the python 2 issue.

Also, we were recalculating the means in the map when we already did so at the pandas level, so I removed that too as it was also causing python 2 problems.

Let me know what you think.