### PR TITLE
Issue 106 retrain leave one out

### DIFF
--- a/category_encoders/leave_one_out.py
+++ b/category_encoders/leave_one_out.py
@@ -80,7 +80,7 @@ class LeaveOneOutEncoder(BaseEstimator, TransformerMixin):
         self.drop_invariant = drop_invariant
         self.drop_cols = []
         self.verbose = verbose
-        self.static_cols = cols
+        self.use_default_cols = cols is None  # important when we call fit() repeatedly
         self.cols = cols
         self._dim = None
         self.mapping = None
@@ -123,7 +123,7 @@ class LeaveOneOutEncoder(BaseEstimator, TransformerMixin):
         self._dim = X.shape[1]
 
         # if columns aren't passed, just use every string column
-        if self.static_cols is None:
+        if self.use_default_cols:
             self.cols = get_obj_cols(X)
 
         categories = self.fit_leave_one_out(

--- a/category_encoders/leave_one_out.py
+++ b/category_encoders/leave_one_out.py
@@ -81,7 +81,7 @@ class LeaveOneOutEncoder(BaseEstimator, TransformerMixin):
         self.drop_cols = []
         self.verbose = verbose
         self.static_cols = cols
-        self.cols = None
+        self.cols = cols
         self._dim = None
         self.mapping = None
         self.impute_missing = impute_missing
@@ -125,8 +125,6 @@ class LeaveOneOutEncoder(BaseEstimator, TransformerMixin):
         # if columns aren't passed, just use every string column
         if self.static_cols is None:
             self.cols = get_obj_cols(X)
-        else:
-            self.cols = self.static_cols
 
         categories = self.fit_leave_one_out(
             X, y,

--- a/category_encoders/tests/test_encoders.py
+++ b/category_encoders/tests/test_encoders.py
@@ -575,7 +575,7 @@ class TestEncoders(unittest.TestCase):
         self.verify_numeric(enc.transform(X_t))
         self.verify_numeric(enc.transform(X_t, y_t))
 
-    def test_fit_callTwiceOnDifferentData_ExpectRefit(self):
+    def test_fit_CallTwiceOnDifferentData_ExpectRefitMapping(self):
         x_a = pd.DataFrame(data=['1', '1', '1', '2', '2', '2'], columns=['col_a'])
         x_b = pd.DataFrame(data=['1', '1', '1', '2', '2', '2'], columns=['col_b'])  # Different column name
         y_dummy = [True, False, True, False, True, False]
@@ -590,6 +590,24 @@ class TestEncoders(unittest.TestCase):
         self.assertEqual('col_b', col_b_mapping['col'])
         self.assertEqual({'sum': 2.0, 'count': 3, 'mean': 2.0/3.0}, col_b_mapping['mapping']['1'])
         self.assertEqual({'sum': 1.0, 'count': 3, 'mean': 01.0/3.0}, col_b_mapping['mapping']['2'])
+
+    def test_transform_CallTwiceOnDifferentData_ExpecCorrectTransformation(self):
+        x_a = pd.DataFrame(data=['1', '1', '1', '2', '2', '2'], columns=['col_a'])
+        x_b = pd.DataFrame(data=['1', '1', '1', '2', '2', '2'], columns=['col_b'])  # Different column name
+        y_dummy = [True, False, True, False, True, False]
+        encoder = encoders.LeaveOneOutEncoder()
+
+        encoder.fit(x_a, y_dummy)
+        encoder.fit(x_b, y_dummy)
+        result = encoder.transform(x_b)['col_b'].values
+
+        self.assertEqual(6, len(result))
+        self.assertEqual(2.0/3.0, result[0])
+        self.assertEqual(2.0 / 3.0, result[1])
+        self.assertEqual(2.0 / 3.0, result[2])
+        self.assertEqual(1.0 / 3.0, result[3])
+        self.assertEqual(1.0 / 3.0, result[4])
+        self.assertEqual(1.0 / 3.0, result[5])
 
     def test_target_encode_np(self):
         """

--- a/category_encoders/tests/test_encoders.py
+++ b/category_encoders/tests/test_encoders.py
@@ -575,6 +575,22 @@ class TestEncoders(unittest.TestCase):
         self.verify_numeric(enc.transform(X_t))
         self.verify_numeric(enc.transform(X_t, y_t))
 
+    def test_fit_callTwiceOnDifferentData_ExpectRefit(self):
+        x_a = pd.DataFrame(data=['1', '1', '1', '2', '2', '2'], columns=['col_a'])
+        x_b = pd.DataFrame(data=['1', '1', '1', '2', '2', '2'], columns=['col_b'])  # Different column name
+        y_dummy = [True, False, True, False, True, False]
+        encoder = encoders.LeaveOneOutEncoder()
+
+        encoder.fit(x_a, y_dummy)
+        encoder.fit(x_b, y_dummy)
+        mapping = encoder.mapping
+
+        self.assertEqual(1, len(mapping))
+        col_b_mapping = mapping[0]
+        self.assertEqual('col_b', col_b_mapping['col'])
+        self.assertEqual({'sum': 2.0, 'count': 3, 'mean': 2.0/3.0}, col_b_mapping['mapping']['1'])
+        self.assertEqual({'sum': 1.0, 'count': 3, 'mean': 01.0/3.0}, col_b_mapping['mapping']['2'])
+
     def test_target_encode_np(self):
         """
 


### PR DESCRIPTION
Addresses https://github.com/scikit-learn-contrib/categorical-encoding/issues/106

To make the LeaveOneEncoder retrainable we follow @janmotl suggestion and split the `leave_one_out` method into methods for fit and transform respectively.

Even once that is done, the refit would fail because fit would set `self.cols` if `cols` is not passed into the constructor. To alleviate that problem, the `cols` from constructor get set to `self.static_cols` and in the fit method we set `self.cols` to `self.static_cols` if it is not none. If `self.static_cols` is None, then set `self.cols` to `get_obj_cols(X)`. So, we can retrain the encoder without specifying the columns in the constructor when each new DataFrame has different columns. That was my solution, please tell me what you think.