### PR TITLE
In the ordinal encoder go ahead and update the existing column instea…

### DIFF
--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -250,9 +250,7 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
             mapping_out = mapping
             for switch in mapping:
                 categories_dict = dict(switch.get('mapping'))
-                X[str(switch.get('col')) + '_tmp'] = X[switch.get('col')].map(lambda x: categories_dict.get(x))
-                del X[switch.get('col')]
-                X.rename(columns={str(switch.get('col')) + '_tmp': switch.get('col')}, inplace=True)
+                X[switch.get('col')] = X[switch.get('col')].map(lambda x: categories_dict.get(x))
 
                 if impute_missing:
                     if handle_unknown == 'impute':
@@ -271,9 +269,7 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
             for col in cols:
                 categories = [x for x in pd.unique(X[col].values) if x is not None]
                 categories_dict = {x: i + 1 for i, x in enumerate(categories)}
-                X[str(col) + '_tmp'] = X[col].map(lambda x: categories_dict.get(x))
-                del X[col]
-                X.rename(columns={str(col) + '_tmp': col}, inplace=True)
+                X[col] = X[col].map(lambda x: categories_dict.get(x))
 
                 if impute_missing:
                     if handle_unknown == 'impute':

--- a/category_encoders/tests/test_encoders.py
+++ b/category_encoders/tests/test_encoders.py
@@ -379,6 +379,19 @@ class TestEncoders(TestCase):
         self.assertTrue(np.isnan(a.values[0, 1]))
         self.assertEqual(a.values[1, 1], 1)
 
+    def test_fit_transform_HaveOriginalColumnOrder_ExpectColumnOrderPreserved(self):
+        df = pd.DataFrame({
+            'SEX': ['Male', 'Male'],
+            'AGE': [34, 20]
+        })
+        encoder = encoders.OrdinalEncoder(handle_unknown='ignore')
+        result = encoder.fit_transform(df)
+        columns = result.columns.values
+
+        self.assertEquals(2, len(columns))
+        self.assertEqual('SEX', columns[0])
+        self.assertEqual('AGE', columns[1])
+
     def test_target_encoder(self):
 
         enc = encoders.TargetEncoder(verbose=1, smoothing=2, min_samples_leaf=2)


### PR DESCRIPTION
To fix https://github.com/scikit-learn-contrib/categorical-encoding/issues/100
 
The issue was arising because `_tmp` columns were being appended to the end of the data frame as part of the transform process. 

First, we noticed that the transform process was to append a temporary column, drop the existing column, and rename the temporary column to the existing column name. 

So, we went ahead and reduced that step to one step where we update the existing column using our mapping which preserves the order. I wasn't sure why the above mentioned transform method had that many steps and a single update causes it to work on my python3.6 system. Will monitor the tests in python2 via CI.