### PR TITLE
Fix TargetEncoder indexing assuming contiguous range index.

### DIFF
--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -212,7 +212,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
             mapping_out = mapping
             for switch in mapping:
                 column = switch.get('col')
-                transformed_column = pd.Series([np.nan] * X.shape[0], name=column)
+                transformed_column = pd.Series(np.nan, index=X.index, name=column)
                 for val in switch.get('mapping'):
                     if switch.get('mapping')[val]['count'] == 1:
                         transformed_column.loc[X[column] == val] = self._mean

--- a/category_encoders/tests/test_target_encoder.py
+++ b/category_encoders/tests/test_target_encoder.py
@@ -51,3 +51,9 @@ class TestTargetEncoder(TestCase):
         self.assertAlmostEqual(0.5874, values[1], delta=1e-4)
         self.assertAlmostEqual(0.4125, values[2], delta=1e-4)
         self.assertEqual(0.5, values[3])
+
+    def test_target_encoder_noncontiguous_index(self):
+        data = pd.DataFrame({'x': ['a', 'b', np.nan, 'd', 'e'], 'y': range(5)}).dropna()
+        result = encoders.TargetEncoder(cols= ['x']).fit_transform(data[['x']], data['y'])
+        self.assertTrue(np.allclose(result, 2.0))
+        


### PR DESCRIPTION
`TargetEncoder` assumed any DataFrame passed to it had and index of 0..N-1, leading to indexing errors when using any other DataFrame.  This copies the input index to the output.

```
data = pd.DataFrame({'x': ['a', 'b', np.nan, 'd', 'e'], 'y': range(5)})
subset = data.dropna()
subset

   x  y
0  a  0
1  b  1
3  d  3
4  e  4
```

```
TargetEncoder(cols= ['x']).fit_transform(subset[['x']], subset['y'])
```

```
IndexingError                             Traceback (most recent call last)
<ipython-input-31-6ccba4dc1798> in <module>()
      2 subset = data.dropna()
      3 subset
----> 4 TargetEncoder(cols= ['x']).fit_transform(subset[['x']], subset['y'])

/local/users/x/venvs/x-Mr1eX5jM/lib/python2.7/site-packages/category_encoders/target_encoder.pyc in fit_transform(self, X, y, **fit_params)
    202             transform(X)
    203         """
--> 204         return self.fit(X, y, **fit_params).transform(X, y)
    205 
    206     def target_encode(self, X_in, y, mapping=None, cols=None, impute_missing=True, handle_unknown='impute', min_samples_leaf=1, smoothing_in=1.0):

/local/users/x/venvs/x-Mr1eX5jM/lib/python2.7/site-packages/category_encoders/target_encoder.pyc in transform(self, X, y)
    183             handle_unknown=self.handle_unknown,
    184             min_samples_leaf=self.min_samples_leaf,
--> 185             smoothing_in=self.smoothing
    186         )
    187 

/local/users/x/venvs/x-Mr1eX5jM/lib/python2.7/site-packages/category_encoders/target_encoder.pyc in target_encode(self, X_in, y, mapping, cols, impute_missing, handle_unknown, min_samples_leaf, smoothing_in)
    216                 for val in switch.get('mapping'):
    217                     if switch.get('mapping')[val]['count'] == 1:
--> 218                         transformed_column.loc[X[column] == val] = self._mean
    219                     else:
    220                         transformed_column.loc[X[column] == val] = switch.get('mapping')[val]['smoothing']

/local/users/x/venvs/x-Mr1eX5jM/lib/python2.7/site-packages/pandas/core/indexing.pyc in __setitem__(self, key, value)
    186         else:
    187             key = com._apply_if_callable(key, self.obj)
--> 188         indexer = self._get_setitem_indexer(key)
    189         self._setitem_with_indexer(indexer, value)
    190 

/local/users/x/venvs/x-Mr1eX5jM/lib/python2.7/site-packages/pandas/core/indexing.pyc in _get_setitem_indexer(self, key)
    172 
    173         try:
--> 174             return self._convert_to_indexer(key, is_setter=True)
    175         except TypeError as e:
    176 

/local/users/x/venvs/x-Mr1eX5jM/lib/python2.7/site-packages/pandas/core/indexing.pyc in _convert_to_indexer(self, obj, axis, is_setter)
   1298 
   1299             if com.is_bool_indexer(obj):
-> 1300                 obj = check_bool_indexer(labels, obj)
   1301                 inds, = obj.nonzero()
   1302                 return inds

/local/users/x/venvs/x-Mr1eX5jM/lib/python2.7/site-packages/pandas/core/indexing.pyc in check_bool_indexer(ax, key)
   2354         mask = isna(result._values)
   2355         if mask.any():
-> 2356             raise IndexingError('Unalignable boolean Series provided as '
   2357                                 'indexer (index of the boolean Series and of '
   2358                                 'the indexed object do not match')

IndexingError: Unalignable boolean Series provided as indexer (index of the boolean Series and of the indexed object do not match
```