### PR TITLE
Speed up TargetEncoder with vectorization.

### DIFF
--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -3,7 +3,6 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
 from category_encoders.utils import get_obj_cols, convert_input, get_generated_cols
-from sklearn.utils.random import check_random_state
 
 __author__ = 'chappers'
 
@@ -89,9 +88,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         self.impute_missing = impute_missing
         self.handle_unknown = handle_unknown
         self._mean = None
-        
-        
-    
+
     def fit(self, X, y, **kwargs):
         """Fit encoder according to X and y.
         Parameters
@@ -110,7 +107,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         # first check the type
         X = convert_input(X)
         if isinstance(y, pd.DataFrame):
-            y = y.iloc[:,0]
+            y = y.iloc[:, 0]
         else:
             y = pd.Series(y, name='target')
         if X.shape[0] != y.shape[0]:
@@ -121,16 +118,15 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         # if columns aren't passed, just use every string column
         if self.cols is None:
             self.cols = get_obj_cols(X)
-        _, categories = self.target_encode(
+        _, self.mapping = self.target_encode(
             X, y,
-            mapping=self.mapping,
+            mapping=None,
             cols=self.cols,
             impute_missing=self.impute_missing,
             handle_unknown=self.handle_unknown,
             smoothing_in=self.smoothing,
             min_samples_leaf=self.min_samples_leaf
         )
-        self.mapping = categories
 
         if self.drop_invariant:
             self.drop_cols = []
@@ -207,43 +203,24 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         X = X_in.copy(deep=True)
         if cols is None:
             cols = X.columns.values
-        
-        if mapping is not None:
-            mapping_out = mapping
-            for switch in mapping:
-                column = switch.get('col')
-                transformed_column = pd.Series([np.nan] * X.shape[0], name=column)
-                for val in switch.get('mapping'):
-                    if switch.get('mapping')[val]['count'] == 1:
-                        transformed_column.loc[X[column] == val] = self._mean
-                    else:
-                        transformed_column.loc[X[column] == val] = switch.get('mapping')[val]['smoothing']
 
+        if mapping is not None:
+            for col in cols:
+                X[col] = X[col].map(mapping[col])
                 if impute_missing:
                     if handle_unknown == 'impute':
-                        transformed_column.fillna(self._mean, inplace=True)
+                        X[col].fillna(self._mean, inplace=True)
                     elif handle_unknown == 'error':
-                        missing = transformed_column.isnull()
-                        if any(missing):
-                            raise ValueError('Unexpected categories found in column %s' % switch.get('col'))
-
-                X[column] = transformed_column.astype(float)
-
+                        if X[col].isnull().any():
+                            raise ValueError('Unexpected categories found in column %s' % col)
         else:
-            self._mean = y.mean()
-            prior = self._mean
-            mapping_out = []
+            mapping = {}
+            prior = self._mean = y.mean()
             for col in cols:
-                tmp = y.groupby(X[col]).agg(['sum', 'count'])
-                tmp['mean'] = tmp['sum'] / tmp['count']
-                tmp = tmp.to_dict(orient='index')
+                stats = y.groupby(X[col]).agg(['count', 'mean'])
+                smoove = 1 / (1 + np.exp(-(stats['count'] - min_samples_leaf) / smoothing_in))
+                smoothing = prior * (1 - smoove) + stats['mean'] * smoove
+                smoothing[stats['count'] == 1] = prior
+                mapping[col] = smoothing
 
-                for val in tmp:
-                    smoothing = smoothing_in
-                    smoothing = 1 / (1 + np.exp(-(tmp[val]["count"] - min_samples_leaf) / smoothing))
-                    cust_smoothing = prior * (1 - smoothing) + tmp[val]['mean'] * smoothing
-                    tmp[val]['smoothing'] = cust_smoothing
-
-                mapping_out.append({'col': col, 'mapping': tmp}, )
-
-        return X, mapping_out
+        return X, mapping

--- a/category_encoders/tests/test_target_encoder.py
+++ b/category_encoders/tests/test_target_encoder.py
@@ -33,10 +33,10 @@ class TestTargetEncoder(TestCase):
              'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
         encoder = encoders.TargetEncoder(cols=['Trend'], min_samples_leaf=k, smoothing=f)
         encoder.fit(binary_cat_example, binary_cat_example['target'])
-        trend_mapping = encoder.mapping[0]['mapping']
-        self.assertAlmostEqual(0.4125, trend_mapping['DOWN']['smoothing'], delta=1e-4)
-        self.assertEqual(0.5, trend_mapping['FLAT']['smoothing'])
-        self.assertAlmostEqual(0.5874, trend_mapping['UP']['smoothing'], delta=1e-4)
+        trend_mapping = encoder.mapping['Trend']
+        self.assertAlmostEqual(0.4125, trend_mapping['DOWN'], delta=1e-4)
+        self.assertEqual(0.5, trend_mapping['FLAT'])
+        self.assertAlmostEqual(0.5874, trend_mapping['UP'], delta=1e-4)
 
     def test_target_encoder_fit_transform_HaveConstructorSetSmoothingAndMinSamplesLeaf_ExpectCorrectValueInResult(self):
         k = 2
@@ -51,3 +51,9 @@ class TestTargetEncoder(TestCase):
         self.assertAlmostEqual(0.5874, values[1], delta=1e-4)
         self.assertAlmostEqual(0.4125, values[2], delta=1e-4)
         self.assertEqual(0.5, values[3])
+
+    def test_target_encoder_noncontiguous_index(self):
+        data = pd.DataFrame({'x': ['a', 'b', np.nan, 'd', 'e'], 'y': range(5)}).dropna()
+        result = encoders.TargetEncoder(cols=['x']).fit_transform(data[['x']], data['y'])
+        self.assertTrue(np.allclose(result, 2.0))
+


### PR DESCRIPTION
Roughly 300X faster and uses less memory.
`fit()` computes category smoothed means with vector ops, stores mapping as (dict of) Series.
`transform()` then just calls Series.map(mapping) to do vectorized lookup with the mapping Series.

Also fixes IndexError when passing DataFrames with non-contiguous indexes.

Also fixes not being able to re-use TargetEncoder by always setting `mapping=None` in `fit()` (you don't want fit to remember anything from previous calls).

```
rows, cats = 1000000, 1000
X = pd.DataFrame({'x': np.random.randint(0, cats, rows).astype(str)})
y = pd.Series(np.random.rand(rows))

# old
%time TargetEncoder().fit_transform(X, y)
CPU times: user 1min 24s, sys: 71.2 ms, total: 1min 24s
Wall time: 1min 24s

# new
%time TargetEncoder().fit_transform(X, y)
CPU times: user 235 ms, sys: 43.6 ms, total: 279 ms
Wall time: 276 ms
```