### PR TITLE
Categorical handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,7 @@ To use:
     encoder = ce.TargetEncoder(cols=[...])
     encoder = ce.WOEEncoder(cols=[...])
 
-All of these are fully compatible sklearn transformers, so they can be used in pipelines or in your existing scripts. If 
-the cols parameter isn't passed, all pandas columns with the object and categorical data type will be encoded. Please see the 
-docs for transformer-specific configuration options.
+All of these are fully compatible sklearn transformers, so they can be used in pipelines or in your existing scripts. Supported input formats include numpy arrays and pandas dataframes. If the cols parameter isn't passed, all columns with object or pandas categorical data type will be encoded. Please see the docs for transformer-specific configuration options.
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To use:
     encoder = ce.WOEEncoder(cols=[...])
 
 All of these are fully compatible sklearn transformers, so they can be used in pipelines or in your existing scripts. If 
-the cols parameter isn't passed, every non-numeric column will be encoded. Please see the 
+the cols parameter isn't passed, all pandas columns with the object and categorical data type will be encoded. Please see the 
 docs for transformer-specific configuration options.
 
 Examples

--- a/category_encoders/basen.py
+++ b/category_encoders/basen.py
@@ -232,7 +232,7 @@ class BaseNEncoder(BaseEstimator, TransformerMixin):
 
         for switch in self.ordinal_encoder.mapping:
             col_dict = {col_pair[1]: col_pair[0] for col_pair in switch.get('mapping')}
-            X[switch.get('col')] = X[switch.get('col')].apply(lambda x: col_dict.get(x))
+            X[switch.get('col')] = X[switch.get('col')].apply(lambda x: col_dict.get(x)).astype(switch.get('data_type'))
 
         return X if self.return_df else X.values
 

--- a/category_encoders/binary.py
+++ b/category_encoders/binary.py
@@ -218,7 +218,7 @@ class BinaryEncoder(BaseEstimator, TransformerMixin):
 
         for switch in self.ordinal_encoder.mapping:
             col_dict = {col_pair[1]: col_pair[0] for col_pair in switch.get('mapping')}
-            X[switch.get('col')] = X[switch.get('col')].apply(lambda x: col_dict.get(x))
+            X[switch.get('col')] = X[switch.get('col')].apply(lambda x: col_dict.get(x)).astype(switch.get('data_type'))
 
         return X if self.return_df else X.values
 

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -231,7 +231,10 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         if not self.use_cat_names:
             for switch in self.ordinal_encoder.mapping:
                 col_dict = {col_pair[1] : col_pair[0] for col_pair in switch.get('mapping')}
-                X[switch.get('col')] = X[switch.get('col')].apply(lambda x:col_dict.get(x))
+                X[switch.get('col')] = X[switch.get('col')].apply(lambda x: col_dict.get(x))
+
+        for switch in self.ordinal_encoder.mapping:
+            X[switch.get('col')] = X[switch.get('col')].astype(switch.get('data_type'))
 
         return X if self.return_df else X.values
 

--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -278,7 +278,6 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
 
                 categories_dict = {x: i + 1 for i, x in enumerate(categories)}
 
-                mapping_out.append({'col': col, 'mapping': [(x[1], x[0] + 1) for x in list(enumerate(categories))],
-                                    'data_type': X[col].dtype}, )
+                mapping_out.append({'col': col, 'mapping': list(categories_dict.items()), 'data_type': X[col].dtype}, )
 
         return X, mapping_out

--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -3,7 +3,7 @@
 import pandas as pd
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
-from category_encoders.utils import get_obj_cols, convert_input, get_generated_cols
+from category_encoders.utils import get_obj_cols, convert_input, get_generated_cols, is_category
 
 __author__ = 'willmcginnis'
 
@@ -270,7 +270,12 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
         else:
             mapping_out = []
             for col in cols:
-                categories = [x for x in pd.unique(X[col].values) if x is not None]
+
+                if is_category(X[col].dtype):
+                    categories = X[col].cat.categories
+                else:
+                    categories = [x for x in pd.unique(X[col].values) if x is not None]
+
                 categories_dict = {x: i + 1 for i, x in enumerate(categories)}
 
                 mapping_out.append({'col': col, 'mapping': [(x[1], x[0] + 1) for x in list(enumerate(categories))],

--- a/category_encoders/tests/test_encoders.py
+++ b/category_encoders/tests/test_encoders.py
@@ -40,7 +40,7 @@ class TestEncoders(TestCase):
     def test_classification(self):
         for encoder_name in encoders.__all__:
             with self.subTest(encoder_name=encoder_name):
-                cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 321]
+                cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 321, 'categorical']
 
                 enc = getattr(encoders, encoder_name)(cols=cols)
                 enc.fit(X, np_y)
@@ -147,7 +147,7 @@ class TestEncoders(TestCase):
         X = tu.create_dataset(n_rows=100, has_none=False)
         X_t = tu.create_dataset(n_rows=50, has_none=False)
         X_t_extra = tu.create_dataset(n_rows=50, extras=True, has_none=False)
-        cols = ['underscore', 'none', 'extra', 321]
+        cols = ['underscore', 'none', 'extra', 321, 'categorical']
 
         for encoder_name in ['BaseNEncoder', 'BinaryEncoder', 'OneHotEncoder', 'OrdinalEncoder']:
             with self.subTest(encoder_name=encoder_name):
@@ -174,7 +174,7 @@ class TestEncoders(TestCase):
             'TimeDelta': [timedelta(-9999), timedelta(-9), timedelta(-1), timedelta(999)],
             'Bool': [False, True, True, False],
             'Tuple': [('a', 'tuple'), ('a', 'tuple'), ('a', 'tuple'), ('b', 'tuple')],
-            # 'Categorical': pd.Categorical(list('bbea'), categories=['e', 'a', 'b'], ordered=True),
+            'Categorical': pd.Categorical(list('bbea'), categories=['e', 'a', 'b'], ordered=True),
             # 'List': [[1,2], [2,3], [3,4], [4,5]],
             # 'Dictionary': [{1: "a", 2: "b"}, {1: "a", 2: "b"}, {1: "a", 2: "b"}, {1: "a", 2: "b"}],
             # 'Set': [{'John', 'Jane'}, {'John', 'Jane'}, {'John', 'Jane'}, {'John', 'Jane'}],

--- a/category_encoders/tests/test_one_hot.py
+++ b/category_encoders/tests/test_one_hot.py
@@ -54,10 +54,9 @@ class TestOneHotEncoderTestCase(TestCase):
         X_i = tu.create_dataset(n_rows=100, has_none=False)
         X_i_t = tu.create_dataset(n_rows=50, has_none=False)
         X_i_t_extra = tu.create_dataset(n_rows=50, extras=True, has_none=False)
-        cols = ['underscore', 'none', 'extra', 321]
+        cols = ['underscore', 'none', 'extra', 321, 'categorical']
 
         enc = encoders.OneHotEncoder(verbose=1, use_cat_names=True, cols=cols)
         enc.fit(X_i)
         obtained = enc.inverse_transform(enc.transform(X_i_t))
-        obtained[321] = obtained[321].astype('int64')   # numeric columns are incorrectly typed as object...
         tu.verify_inverse_transform(X_i_t, obtained)

--- a/category_encoders/tests/test_ordinal.py
+++ b/category_encoders/tests/test_ordinal.py
@@ -58,3 +58,18 @@ class TestOrdinalEncoder(TestCase):
         a = encoder.transform(data)
         self.assertTrue(np.isnan(a.values[0, 1]))
         self.assertEqual(a.values[1, 1], 1)
+
+    def test_pandas_categorical(self):
+        X = pd.DataFrame({
+            'Str': ['a', 'c', 'c', 'd'],
+            'Categorical': pd.Categorical(list('bbea'), categories=['e', 'a', 'b'], ordered=True)
+        })
+
+        enc = encoders.OrdinalEncoder()
+        out = enc.fit_transform(X)
+
+        tu.verify_numeric(out)
+        self.assertEqual(3, out['Categorical'][0])
+        self.assertEqual(3, out['Categorical'][1])
+        self.assertEqual(1, out['Categorical'][2])
+        self.assertEqual(2, out['Categorical'][3])

--- a/category_encoders/tests/test_target_encoder.py
+++ b/category_encoders/tests/test_target_encoder.py
@@ -52,7 +52,7 @@ class TestTargetEncoder(TestCase):
         self.assertAlmostEqual(0.4125, values[2], delta=1e-4)
         self.assertEqual(0.5, values[3])
 
-    def test_target_encoder_fit_transform_HaveCategoricalCOlumn_ExpectCorrectValueInResult(self):
+    def test_target_encoder_fit_transform_HaveCategoricalColumn_ExpectCorrectValueInResult(self):
         k = 2
         f = 10
         binary_cat_example = pd.DataFrame(

--- a/category_encoders/tests/test_target_encoder.py
+++ b/category_encoders/tests/test_target_encoder.py
@@ -52,6 +52,21 @@ class TestTargetEncoder(TestCase):
         self.assertAlmostEqual(0.4125, values[2], delta=1e-4)
         self.assertEqual(0.5, values[3])
 
+    def test_target_encoder_fit_transform_HaveCategoricalCOlumn_ExpectCorrectValueInResult(self):
+        k = 2
+        f = 10
+        binary_cat_example = pd.DataFrame(
+            {'Trend': pd.Categorical(['UP', 'UP', 'DOWN', 'FLAT', 'DOWN', 'UP', 'DOWN', 'FLAT', 'FLAT', 'FLAT'],
+                                     categories=['UP', 'FLAT', 'DOWN']),
+             'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
+        encoder = encoders.TargetEncoder(cols=['Trend'], min_samples_leaf=k, smoothing=f)
+        result = encoder.fit_transform(binary_cat_example, binary_cat_example['target'])
+        values = result['Trend'].values
+        self.assertAlmostEqual(0.5874, values[0], delta=1e-4)
+        self.assertAlmostEqual(0.5874, values[1], delta=1e-4)
+        self.assertAlmostEqual(0.4125, values[2], delta=1e-4)
+        self.assertEqual(0.5, values[3])
+
     def test_target_encoder_noncontiguous_index(self):
         data = pd.DataFrame({'x': ['a', 'b', np.nan, 'd', 'e'], 'y': range(5)}).dropna()
         result = encoders.TargetEncoder(cols=['x']).fit_transform(data[['x']], data['y'])

--- a/category_encoders/tests/test_utils.py
+++ b/category_encoders/tests/test_utils.py
@@ -45,10 +45,12 @@ def create_dataset(n_rows=1000, extras=False, has_none=True):
         random.choice(['A', 'B_b', 'C_c_c']),                                                   # Strings with underscores to test reverse_dummies()
         random.choice(['A', 'B', 'C', None]) if has_none else random.choice(['A', 'B', 'C']),   # None
         random.choice(['A', 'B', 'C', 'D']) if extras else random.choice(['A', 'B', 'C']),      # With a new string value
-        random.choice([12, 43, -32])                                                            # Number in the column name
+        random.choice([12, 43, -32]),                                                           # Number in the column name
+        random.choice(['A', 'B', 'C']),                                                         # What is going to become the categorical column
     ] for row in range(n_rows)]
 
-    df = pd.DataFrame(ds, columns=['float', 'float_edge', 'unique_int', 'unique_str', 'invariant', 'underscore', 'none', 'extra', 321])
+    df = pd.DataFrame(ds, columns=['float', 'float_edge', 'unique_int', 'unique_str', 'invariant', 'underscore', 'none', 'extra', 321, 'categorical'])
+    df['categorical'] = pd.Categorical(df['categorical'], categories=['A', 'B', 'C'])
     return df
 
 

--- a/category_encoders/tests/test_woe.py
+++ b/category_encoders/tests/test_woe.py
@@ -17,7 +17,7 @@ y_t = pd.DataFrame(np_y_t)
 
 class TestWeightOfEvidenceEncoder(TestCase):
     def test_woe(self):
-        cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 321]
+        cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 321, 'categorical']
 
         # balanced label with balanced features
         X_balanced = pd.DataFrame(data=['1', '1', '1', '2', '2', '2'], columns=['col1'])

--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -13,10 +13,14 @@ def get_obj_cols(df):
     """
     obj_cols = []
     for idx, dt in enumerate(df.dtypes):
-        if dt == 'object' or pd.api.types.is_categorical_dtype(dt):
+        if dt == 'object' or is_category(dt):
             obj_cols.append(df.columns.values[idx])
 
     return obj_cols
+
+
+def is_category(dtype):
+    return pd.api.types.is_categorical_dtype(dtype)
 
 
 def convert_input(X):

--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -13,7 +13,7 @@ def get_obj_cols(df):
     """
     obj_cols = []
     for idx, dt in enumerate(df.dtypes):
-        if dt == 'object':
+        if dt == 'object' or pd.api.types.is_categorical_dtype(dt):
             obj_cols.append(df.columns.values[idx])
 
     return obj_cols


### PR DESCRIPTION
Addresses https://github.com/scikit-learn-contrib/categorical-encoding/issues/86

@janmotl Here is my approach to setting up categorical datatype compatibility.

I've also started storing the datatype of the column so that way the inverse transform can set the types correctly. Luckily, there were not a lot of core things that had to change.

I was also able to ensure the ordinal encoder set it's values by the order of the categories in the data type.

Tell me what you think.