### PR TITLE
Speed up LeaveOneOutEncoder with vectorization.

### DIFF
--- a/category_encoders/leave_one_out.py
+++ b/category_encoders/leave_one_out.py
@@ -32,10 +32,9 @@ class LeaveOneOutEncoder(BaseEstimator, TransformerMixin):
         options are 'error', 'ignore' and 'impute', defaults to 'impute', which will impute the category -1. Warning: if
         impute is used, an extra column will be added in if the transform matrix has unknown categories.  This can causes
         unexpected changes in dimension in some cases.
-    randomized: bool
-        adds normal (Gaussian) distribution noise into training data in order to decrease overfitting (testing data are untouched).
     sigma: float
-        standard deviation (spread or "width") of the normal distribution.
+        adds normal (Gaussian) distribution noise into training data in order to decrease overfitting (testing data are untouched).
+        sigma gives the standard deviation (spread or "width") of the normal distribution.
 
     Example
     -------
@@ -76,7 +75,7 @@ class LeaveOneOutEncoder(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, verbose=0, cols=None, drop_invariant=False, return_df=True, impute_missing=True,
-                 handle_unknown='impute', random_state=None, randomized=False, sigma=0.05):
+                 handle_unknown='impute', random_state=None, sigma=None):
         self.return_df = return_df
         self.drop_invariant = drop_invariant
         self.drop_cols = []
@@ -89,7 +88,6 @@ class LeaveOneOutEncoder(BaseEstimator, TransformerMixin):
         self.handle_unknown = handle_unknown
         self._mean = None
         self.random_state = random_state
-        self.randomized = randomized
         self.sigma = sigma
 
     def fit(self, X, y, **kwargs):
@@ -245,7 +243,7 @@ class LeaveOneOutEncoder(BaseEstimator, TransformerMixin):
                     if X[col].isnull().any():
                         raise ValueError('Unexpected categories found in column %s' % col)
 
-            if self.randomized and y is not None:
+            if self.sigma is not None and y is not None:
                 X[col] = X[col] * random_state_.normal(1., self.sigma, X[col].shape[0])
 
         return X

--- a/category_encoders/tests/test_leave_one_out.py
+++ b/category_encoders/tests/test_leave_one_out.py
@@ -19,7 +19,7 @@ y_t = pd.DataFrame(np_y_t)
 class TestLeaveOneOutEncoder(TestCase):
 
     def test_leave_one_out(self):
-        enc = encoders.LeaveOneOutEncoder(verbose=1, randomized=True, sigma=0.1)
+        enc = encoders.LeaveOneOutEncoder(verbose=1, sigma=0.1)
         enc.fit(X, y)
         tu.verify_numeric(enc.transform(X_t))
         tu.verify_numeric(enc.transform(X_t, y_t))
@@ -32,7 +32,7 @@ class TestLeaveOneOutEncoder(TestCase):
         X = df.drop('outcome', axis=1)
         y = df.drop('color', axis=1)
 
-        ce_leave = encoders.LeaveOneOutEncoder(cols=['color'], randomized=False)
+        ce_leave = encoders.LeaveOneOutEncoder(cols=['color'])
         obtained = ce_leave.fit_transform(X, y['outcome'])
 
         self.assertEqual([0.0, 0.5, 0.5, 0.5, 1.0, 0.5], list(obtained['color']))


### PR DESCRIPTION
Over 400X faster while using less memory.

Store category mappings as DataFrames, then do vectorized apply
with `.map()`.  `fit()` just computes the sum and count of `y` for each
level of each column of `X`.  These mappings are stored as a dict
mapping the column name to a DataFrame with `sum` and `count` columns.
`transform()` then applies the map to each column of `X`, plus a little
vectorized math.

There is a speed/space tradeoff, whether to store the mean of `y`
for each level as well as the sum and count.  This was resolved
in favor of space, recomputing the mean in `transform()`, so that
e.g. pickled Transformers will take less space on disk.

```
rows, cats = 1000000, 1000
X = pd.DataFrame({'x': np.random.randint(0, cats, rows).astype(str)})
y = pd.Series(np.random.rand(rows))

# old
%time LeaveOneOutEncoder().fit_transform(X, y)
CPU times: user 2min 47s, sys: 241 ms, total: 2min 48s
Wall time: 2min 48s

# new
CPU times: user 390 ms, sys: 17.3 ms, total: 408 ms
Wall time: 407 ms
```
