### PR TITLE
Fix index duplication problem in hahsing encoder by using pd concat i…

### DIFF
--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -234,12 +234,12 @@ class HashingEncoder(BaseEstimator, TransformerMixin):
 
         new_cols = ['col_%d' % d for d in range(N)]
 
-        X_cat = X.reindex(columns=cols)
-        X_num = X.reindex(columns=[x for x in X.columns.values if x not in cols])
+        X_cat = X.loc[:, cols]
+        X_num = X.loc[:, [x for x in X.columns.values if x not in cols]]
 
         X_cat = X_cat.apply(hash_fn, axis=1)
         X_cat.columns = new_cols
 
-        X = pd.merge(X_cat, X_num, left_index=True, right_index=True)
+        X = pd.concat([X_cat, X_num], axis=1)
 
         return X

--- a/category_encoders/tests/test_encoders.py
+++ b/category_encoders/tests/test_encoders.py
@@ -263,3 +263,12 @@ class TestEncoders(TestCase):
                 enc = getattr(encoders, encoder_name)(cols=['x'])
                 data = pd.DataFrame({'x': ['a', 'b', np.nan, 'd', 'e'], 'y': [1, 0, 1, 0, 1]}).dropna()
                 _ = enc.fit_transform(data[['x']], data['y'])
+
+    def test_duplicate_index_value(self):
+        for encoder_name in encoders.__all__:
+            with self.subTest(encoder_name=encoder_name):
+                enc = getattr(encoders, encoder_name)(cols=['x'])
+                data = pd.DataFrame({'x': ['a', 'b', 'c', 'd', 'e'], 'y': [1, 0, 1, 0, 1]}, index=[1, 2, 2, 3, 4])
+                result = enc.fit_transform(data[['x']], data['y'])
+                self.assertEqual(5, len(result))
+


### PR DESCRIPTION
Addresses https://github.com/scikit-learn-contrib/categorical-encoding/issues/147

To fix this I opted to use `pd.concat` to simply combine the number and category dataframes. Before I do so, I use `loc` to get the right columns we need and preserve the indexes.

Tell me what you think.