### PR TITLE
Fix basen and onehot inverse transform colnames

### DIFF
--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -372,26 +372,24 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         numerical: DataFrame
 
         """
-        out_cols = X.columns.values
-        cols = []
+        out_cols = X.columns.values.tolist()
         mapped_columns = []
         for switch in mapping:
             col = switch.get('col')
             mod = switch.get('mapping')
-            cols.append(col)
+            insert_at = out_cols.index(mod.columns[0])
 
-            X[col] = 0
+            X.insert(insert_at, col, 0)
             positive_indexes = mod.index[mod.index > 0]
             for i in range(positive_indexes.shape[0]):
                 existing_col = mod.columns[i]
                 val = positive_indexes[i]
-
                 X.loc[X[existing_col] == 1, col] = val
                 mapped_columns.append(existing_col)
+            X.drop(mod.columns, axis=1, inplace=True)
+            out_cols = X.columns.values.tolist()
 
-        out_cols = [col0 for col0 in out_cols if col0 not in mapped_columns]
-
-        return X.reindex(columns=out_cols + cols)
+        return X
 
     def get_feature_names(self):
         """

--- a/category_encoders/tests/test_encoders.py
+++ b/category_encoders/tests/test_encoders.py
@@ -48,7 +48,7 @@ class TestEncoders(TestCase):
     def test_classification(self):
         for encoder_name in encoders.__all__:
             with self.subTest(encoder_name=encoder_name):
-                cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 321, 'categorical']
+                cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 321, 'categorical', 'na_categorical']
 
                 enc = getattr(encoders, encoder_name)(cols=cols)
                 enc.fit(X, np_y)

--- a/category_encoders/tests/test_polynomial.py
+++ b/category_encoders/tests/test_polynomial.py
@@ -2,7 +2,7 @@ import pandas as pd
 from unittest2 import TestCase  # or `from unittest import ...` if on Python 3.4+
 import numpy as np
 import category_encoders as encoders
-from category_encoders.tests.test_helpers import deep_round
+from category_encoders.tests.helpers import deep_round
 
 a_encoding = [1, -0.7071067811865476, 0.40824829046386313]
 b_encoding = [1, -5.551115123125783e-17, -0.8164965809277261]

--- a/category_encoders/tests/test_woe.py
+++ b/category_encoders/tests/test_woe.py
@@ -17,7 +17,7 @@ y_t = pd.DataFrame(np_y_t)
 
 class TestWeightOfEvidenceEncoder(TestCase):
     def test_woe(self):
-        cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 321, 'categorical']
+        cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 321, 'categorical', 'na_categorical']
 
         # balanced label with balanced features
         X_balanced = pd.DataFrame(data=['1', '1', '1', '2', '2', '2'], columns=['col1'])


### PR DESCRIPTION
Both had an issue with the order of columns when doing inverse_transform.

This is fixed. Also, the new column na_categorical that is added in tests.helper is now present in test_encoders.test_classification(), making all tests pass.