### PR TITLE
Added support for 'y' with string data.

### DIFF
--- a/category_encoders/cat_boost.py
+++ b/category_encoders/cat_boost.py
@@ -5,6 +5,7 @@ import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
 import category_encoders.utils as util
 from sklearn.utils.random import check_random_state
+from sklearn.preprocessing import LabelEncoder
 
 __author__ = 'Jan Motl'
 
@@ -106,6 +107,7 @@ class CatBoostEncoder(BaseEstimator, TransformerMixin):
         self.sigma = sigma
         self.feature_names = None
         self.a = a
+        self.le_ = None
 
     def fit(self, X, y, **kwargs):
         """Fit encoder according to X and y.
@@ -129,6 +131,10 @@ class CatBoostEncoder(BaseEstimator, TransformerMixin):
 
         # unite the input into pandas types
         X = util.convert_input(X)
+        # encode the label into integers
+        self.le_ = LabelEncoder().fit(y)
+        y = self.le_.transform(y)
+        y = y.astype(int)
         y = util.convert_input_vector(y, X.index).astype(float)
 
         if X.shape[0] != y.shape[0]:
@@ -204,6 +210,10 @@ class CatBoostEncoder(BaseEstimator, TransformerMixin):
 
         # if we are encoding the training data, we have to check the target
         if y is not None:
+            # Encode labels from string to float (if not already float)
+            if y.dtype != np.float64:
+                y = self.le_.transform(y)
+
             y = util.convert_input_vector(y, X.index).astype(float)
             if X.shape[0] != y.shape[0]:
                 raise ValueError("The length of X is " + str(X.shape[0]) + " but length of y is " + str(y.shape[0]) + ".")


### PR DESCRIPTION
Previous version of CatBoostEncoder only works with numerical 'y', this update added support for string label for 'y'.