### PR TITLE
Fix OrdinalEncoder with categorical columns containing NaN values

### DIFF
--- a/category_encoders/tests/test_ordinal.py
+++ b/category_encoders/tests/test_ordinal.py
@@ -73,22 +73,27 @@ class TestOrdinalEncoder(TestCase):
         self.assertEqual(2, out['Categorical'][3])
 
     def test_handle_missing_have_nan_fit_time_expect_as_category(self):
-        train = pd.DataFrame({'city': ['chicago', np.nan]})
+        train = pd.DataFrame({'city': ['chicago', np.nan],
+                              'city_cat': pd.Categorical(['chicago', np.nan])})
 
         enc = encoders.OrdinalEncoder(handle_missing='value')
         out = enc.fit_transform(train)
 
         self.assertListEqual([1, 2], out['city'].tolist())
+        self.assertListEqual([1, 2], out['city_cat'].tolist())
 
     def test_handle_missing_have_nan_transform_time_expect_negative_2(self):
-        train = pd.DataFrame({'city': ['chicago', 'st louis']})
-        test = pd.DataFrame({'city': ['chicago', np.nan]})
+        train = pd.DataFrame({'city': ['chicago', 'st louis'],
+                              'city_cat': pd.Categorical(['chicago', 'st louis'])})
+        test = pd.DataFrame({'city': ['chicago', np.nan],
+                             'city_cat': pd.Categorical(['chicago', np.nan])})
 
         enc = encoders.OrdinalEncoder(handle_missing='value')
         enc.fit(train)
         out = enc.transform(test)
 
         self.assertListEqual([1, -2], out['city'].tolist())
+        self.assertListEqual([1, -2], out['city_cat'].tolist())
 
     def test_handle_unknown_have_new_value_expect_negative_1(self):
         train = pd.DataFrame({'city': ['chicago', 'st louis']})


### PR DESCRIPTION
OrdinalEncoder and OneHotEncoder display incorrect results with categorical columns that include NaN values. 

```python
import numpy as np
import pandas as pd

from category_encoders import OrdinalEncoder, OneHotEncoder

X = pd.DataFrame({
        'A': pd.Categorical(['a', 'b', 'c', 'a', np.nan]),
        'B': ['a', 'b', 'c', 'a', np.nan]
})

# We expect the same results on both columns
OrdinalEncoder().fit_transform(X)
#>                      A  B
0                    1  1
1                    2  2
2                    3  3
3                    1  1
4 -9223372036854775808  4
OneHotEncoder(use_cat_names = True).fit_transform(X)
#>    A_a  A_b  A_c  B_a  B_b  B_c  B_nan
0  1.0  0.0  0.0    1    0    0      0
1  0.0  1.0  0.0    0    1    0      0
2  0.0  0.0  1.0    0    0    1      0
3  1.0  0.0  0.0    1    0    0      0
4  NaN  NaN  NaN    0    0    0      1
```

<sup>Created on 2019-10-30 by the [reprexpy package](https://github.com/crew102/reprexpy)</sup>

The bug results from the fact that pandas doesn't include NaN in categories. This PR fixes the issue in OrdinalEncoder. OneHotEncoder relies on OrdinalEncoder, so it fixes OneHotEncoder as well. 

I also added tests for this specific case. 