### PR TITLE
convert index to python list

### DIFF
--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -194,7 +194,7 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
         if X.shape[1] != self._dim:
             raise ValueError('Unexpected input dimension %d, expected %d' % (X.shape[1], self._dim,))
 
-        if not self.cols:
+        if not list(self.cols):
             return X if self.return_df else X.values
 
         X, _ = self.ordinal_encoding(


### PR DESCRIPTION
Since pandas dataframe columns may be pd.Index objects, evaluating them in an if statement may throw an error. converting to a list allows for python to use it's native list boolean evaluation which is pretty robust.

I haven't tested it much at all but there are a fairly few downsides to doing the conversion in the context if an if statement.

Opening the PR just to let you guys know there might be some low hanging fruit available. Will read the guidelines and do a proper one if I find time.