### PR TITLE
Determine unique values from data, not pandas.cat

### DIFF
--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -320,10 +320,15 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
 
                 nan_identity = np.nan
 
-                # Avoid using pandas category dtype meta-data, see #235
-                categories = X[col].unique().tolist()
-                if util.is_category(X[col].dtype) and X[col].isna().any():
-                    categories += [np.nan]
+                if util.is_category(X[col].dtype):
+                    # Avoid using pandas category dtype meta-data if possible, see #235, #238.
+                    categories = X[col].unique().tolist()
+                    if X[col].dtype.ordered:
+                        categories = [c for c in X[col].dtype.categories if c in categories]
+                    if X[col].isna().any():
+                        categories += [np.nan]
+                else:
+                    categories = X[col].unique()
 
                 index = pd.Series(categories).fillna(nan_identity).unique()
 

--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -320,15 +320,13 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
 
                 nan_identity = np.nan
 
+                categories = X[col].unique().tolist()
                 if util.is_category(X[col].dtype):
                     # Avoid using pandas category dtype meta-data if possible, see #235, #238.
-                    categories = X[col].unique().tolist()
                     if X[col].dtype.ordered:
                         categories = [c for c in X[col].dtype.categories if c in categories]
                     if X[col].isna().any():
                         categories += [np.nan]
-                else:
-                    categories = X[col].unique()
 
                 index = pd.Series(categories).fillna(nan_identity).unique()
 

--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -320,12 +320,10 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
 
                 nan_identity = np.nan
 
-                if util.is_category(X[col].dtype):
-                    categories = X[col].cat.categories.tolist()
-                    if X[col].isna().any():
-                        categories += [np.nan]
-                else:
-                    categories = X[col].unique()
+                # Avoid using pandas category dtype meta-data, see #235
+                categories = X[col].unique().tolist()
+                if util.is_category(X[col].dtype) and X[col].isna().any():
+                    categories += [np.nan]
 
                 index = pd.Series(categories).fillna(nan_identity).unique()
 

--- a/category_encoders/tests/test_ordinal.py
+++ b/category_encoders/tests/test_ordinal.py
@@ -106,6 +106,19 @@ class TestOrdinalEncoder(TestCase):
 
         self.assertEqual(expected, result)
 
+    def test_handle_unknown_have_new_value_expect_negative_1_categorical(self):
+        cities = ['st louis', 'chicago', 'los angeles']
+        train = pd.DataFrame({'city': pd.Categorical(cities[:-1], categories=cities)})
+        test = pd.DataFrame({'city': pd.Categorical(cities[1:], categories=cities)})
+
+        expected = [2.0, -1.0]
+
+        enc = encoders.OrdinalEncoder(handle_missing='return_nan')
+        enc.fit(train)
+        result = enc.transform(test)['city'].tolist()
+
+        self.assertEqual(expected, result)
+
     def test_custom_mapping(self):
         # See issue 193
         custom_mapping = [{'col': 'col1', 'mapping': {np.NaN: 0, 'a': 1, 'b': 2}},  # The mapping from the documentation


### PR DESCRIPTION
Closes #235.

When using the meta-data of the pandas categorical dtype to determine
all unique values, it might create an encoding for values not present in
the data. Ignoring the meta-data and using the seen unique values
instead ensures proper behavior when a new value occurs in the test
data. It will be handled through the handle_unknown strategy
accordingly.

---

This PR is opened prematurely, sorry for that. I still need to add test the fix and add a unit test.
Unfortunately I encountered issues running the unit tests locally.
I tried to, but got this error while running tests (on Py3.6.10, with pandas 1.0.1 and 0.25.3):

```
Traceback (most recent call last):
  File "~\continuum\anaconda3\envs\ce\lib\multiprocessing\process.py", line 258, in _bootstrap
    self.run()
  File "~\continuum\anaconda3\envs\ce\lib\multiprocessing\process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "~\repositories\forks\categorical-encoding\category_encoders\hashing.py", line 203, in require_data
    data_part = self.hashing_trick(X_in=data_part, hashing_method=self.hash_method, N=self.n_components, cols=self.cols)
  File "~\repositories\forks\categorical-encoding\category_encoders\hashing.py", line 391, in hashing_trick
    X_cat.columns = new_cols
  File "~\continuum\anaconda3\envs\ce\lib\site-packages\pandas\core\generic.py", line 5287, in __setattr__
    return object.__setattr__(self, name, value)
  File "pandas\_libs\properties.pyx", line 67, in pandas._libs.properties.AxisProperty.__set__
  File "~\continuum\anaconda3\envs\ce\lib\site-packages\pandas\core\generic.py", line 661, in _set_axis
    self._data.set_axis(axis, labels)
  File "~\continuum\anaconda3\envs\ce\lib\site-packages\pandas\core\internals\managers.py", line 178, in set_axis
    f"Length mismatch: Expected axis has {old_len} elements, new "
ValueError: Length mismatch: Expected axis has 1 elements, new values have 8 elements
```

I am not sure if I am testing with wrong versions here, is there documentation on the developer requirements?
I installed:

```
nose
coverage
unittest2
```
