### PR TITLE
Fix Error Message in Fit_Transform

### DIFF
--- a/category_encoders/cat_boost.py
+++ b/category_encoders/cat_boost.py
@@ -2,14 +2,14 @@
 
 import numpy as np
 import pandas as pd
-from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.base import BaseEstimator
 import category_encoders.utils as util
 from sklearn.utils.random import check_random_state
 
 __author__ = 'Jan Motl'
 
 
-class CatBoostEncoder(BaseEstimator, TransformerMixin):
+class CatBoostEncoder(BaseEstimator, util.TransformerWithTargetMixin):
     """CatBoost coding for categorical features.
 
     This is very similar to leave-one-out encoding, but calculates the
@@ -223,20 +223,6 @@ class CatBoostEncoder(BaseEstimator, TransformerMixin):
             return X
         else:
             return X.values
-
-    def fit_transform(self, X, y=None, **fit_params):
-        """
-        Encoders that utilize the target must make sure that the training data are transformed with:
-             transform(X, y)
-        and not with:
-            transform(X)
-        """
-
-        # the interface requires 'y=None' in the signature but we need 'y'
-        if y is None:
-            raise(TypeError, 'fit_transform() missing argument: ''y''')
-
-        return self.fit(X, y, **fit_params).transform(X, y)
 
     def _fit(self, X_in, y, cols=None):
         X = X_in.copy(deep=True)

--- a/category_encoders/james_stein.py
+++ b/category_encoders/james_stein.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import scipy
 from scipy import optimize
-from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.base import BaseEstimator
 from category_encoders.ordinal import OrdinalEncoder
 import category_encoders.utils as util
 from sklearn.utils.random import check_random_state
@@ -11,7 +11,7 @@ from sklearn.utils.random import check_random_state
 __author__ = 'Jan Motl'
 
 
-class JamesSteinEncoder(BaseEstimator, TransformerMixin):
+class JamesSteinEncoder(BaseEstimator, util.TransformerWithTargetMixin):
     """James-Stein estimator.
 
     For feature value `i`, James-Stein estimator returns a weighted average of:
@@ -308,20 +308,6 @@ class JamesSteinEncoder(BaseEstimator, TransformerMixin):
             return X
         else:
             return X.values
-
-    def fit_transform(self, X, y=None, **fit_params):
-        """
-        Encoders that utilize the target must make sure that the training data are transformed with:
-            transform(X, y)
-        and not with:
-            transform(X)
-        """
-
-        # the interface requires 'y=None' in the signature but we need 'y'
-        if y is None:
-            raise(TypeError, 'fit_transform() missing argument: ''y''')
-
-        return self.fit(X, y, **fit_params).transform(X, y)
 
     def _train_pooled(self, X, y):
         # Implemented based on reference [1]

--- a/category_encoders/leave_one_out.py
+++ b/category_encoders/leave_one_out.py
@@ -1,14 +1,14 @@
 """Leave one out coding"""
 import numpy as np
 import pandas as pd
-from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.base import BaseEstimator
 import category_encoders.utils as util
 from sklearn.utils.random import check_random_state
 
 __author__ = 'hbghhy'
 
 
-class LeaveOneOutEncoder(BaseEstimator, TransformerMixin):
+class LeaveOneOutEncoder(BaseEstimator, util.TransformerWithTargetMixin):
     """Leave one out coding for categorical features.
 
     This is very similar to target encoding but excludes the current row's
@@ -209,20 +209,6 @@ class LeaveOneOutEncoder(BaseEstimator, TransformerMixin):
             return X
         else:
             return X.values
-
-    def fit_transform(self, X, y=None, **fit_params):
-        """
-        Encoders that utilize the target must make sure that the training data are transformed with:
-             transform(X, y)
-        and not with:
-            transform(X)
-        """
-
-        # the interface requires 'y=None' in the signature but we need 'y'
-        if y is None:
-            raise(TypeError, 'fit_transform() missing argument: ''y''')
-
-        return self.fit(X, y, **fit_params).transform(X, y)
 
     def fit_leave_one_out(self, X_in, y, cols=None):
         X = X_in.copy(deep=True)

--- a/category_encoders/m_estimate.py
+++ b/category_encoders/m_estimate.py
@@ -1,7 +1,7 @@
 """M-probability estimate"""
 import numpy as np
 import pandas as pd
-from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.base import BaseEstimator
 from category_encoders.ordinal import OrdinalEncoder
 import category_encoders.utils as util
 from sklearn.utils.random import check_random_state
@@ -9,7 +9,7 @@ from sklearn.utils.random import check_random_state
 __author__ = 'Jan Motl'
 
 
-class MEstimateEncoder(BaseEstimator, TransformerMixin):
+class MEstimateEncoder(BaseEstimator, util.TransformerWithTargetMixin):
     """M-probability estimate of likelihood.
 
     This is a simplified version of target encoder, which goes under names like m-probability estimate or
@@ -240,20 +240,6 @@ class MEstimateEncoder(BaseEstimator, TransformerMixin):
             return X
         else:
             return X.values
-
-    def fit_transform(self, X, y=None, **fit_params):
-        """
-        Encoders that utilize the target must make sure that the training data are transformed with:
-            transform(X, y)
-        and not with:
-            transform(X)
-        """
-
-        # the interface requires 'y=None' in the signature but we need 'y'
-        if y is None:
-            raise(TypeError, 'fit_transform() missing argument: ''y''')
-
-        return self.fit(X, y, **fit_params).transform(X, y)
 
     def _train(self, X, y):
         # Initialize the output

--- a/category_encoders/mixed.py
+++ b/category_encoders/mixed.py
@@ -3,7 +3,7 @@ import warnings
 import re
 import numpy as np
 import pandas as pd
-from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.base import BaseEstimator
 from sklearn.utils.random import check_random_state
 from category_encoders.ordinal import OrdinalEncoder
 import category_encoders.utils as util
@@ -13,7 +13,7 @@ from statsmodels.genmod.bayes_mixed_glm import BinomialBayesMixedGLM as bgmm
 __author__ = 'Jan Motl'
 
 
-class MixedEncoder(BaseEstimator, TransformerMixin):
+class MixedEncoder(BaseEstimator, util.TransformerWithTargetMixin):
     """Generalized linear mixed model.
 
     This is a supervised encoder similar to TargetEncoder or MEstimateEncoder, but there are some advantages:
@@ -242,20 +242,6 @@ class MixedEncoder(BaseEstimator, TransformerMixin):
             return X
         else:
             return X.values
-
-    def fit_transform(self, X, y=None, **fit_params):
-        """
-        Encoders that utilize the target must make sure that the training data are transformed with:
-            transform(X, y)
-        and not with:
-            transform(X)
-        """
-
-        # the interface requires 'y=None' in the signature but we need 'y'
-        if y is None:
-            raise(TypeError, 'fit_transform() missing argument: ''y''')
-
-        return self.fit(X, y, **fit_params).transform(X, y)
 
     def _train(self, X, y):
         # Initialize the output

--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -1,14 +1,14 @@
 """Target Encoder"""
 import numpy as np
 import pandas as pd
-from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.base import BaseEstimator
 from category_encoders.ordinal import OrdinalEncoder
 import category_encoders.utils as util
 
 __author__ = 'chappers'
 
 
-class TargetEncoder(BaseEstimator, TransformerMixin):
+class TargetEncoder(BaseEstimator, util.TransformerWithTargetMixin):
     """Target encoding for categorical features.
 
     For the case of categorical target: features are replaced with a blend of posterior probability of the target
@@ -242,20 +242,6 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
             return X
         else:
             return X.values
-
-    def fit_transform(self, X, y=None, **fit_params):
-        """
-        Encoders that utilize the target must make sure that the training data are transformed with:
-             transform(X, y)
-        and not with:
-            transform(X)
-        """
-
-        # the interface requires 'y=None' in the signature but we need 'y'
-        if y is None:
-            raise(TypeError, 'fit_transform() missing argument: ''y''')
-
-        return self.fit(X, y, **fit_params).transform(X, y)
 
     def target_encode(self, X_in):
         X = X_in.copy(deep=True)

--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -135,3 +135,16 @@ def get_generated_cols(X_original, X_transformed, to_transform):
         [current_cols.remove(c) for c in original_cols]
 
     return current_cols
+
+
+class TransformerWithTargetMixin:
+    def fit_transform(self, X, y=None, **fit_params):
+        """
+        Encoders that utilize the target must make sure that the training data are transformed with:
+             transform(X, y)
+        and not with:
+            transform(X)
+        """
+        if y is None:
+            raise TypeError('fit_transform() missing argument: ''y''')
+        return self.fit(X, y, **fit_params).transform(X, y)

--- a/category_encoders/woe.py
+++ b/category_encoders/woe.py
@@ -1,7 +1,7 @@
 """Weight of Evidence"""
 import numpy as np
 import pandas as pd
-from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.base import BaseEstimator
 from category_encoders.ordinal import OrdinalEncoder
 import category_encoders.utils as util
 from sklearn.utils.random import check_random_state
@@ -9,7 +9,7 @@ from sklearn.utils.random import check_random_state
 __author__ = 'Jan Motl'
 
 
-class WOEEncoder(BaseEstimator, TransformerMixin):
+class WOEEncoder(BaseEstimator, util.TransformerWithTargetMixin):
     """Weight of Evidence coding for categorical features.
 
     Parameters
@@ -238,20 +238,6 @@ class WOEEncoder(BaseEstimator, TransformerMixin):
             return X
         else:
             return X.values
-
-    def fit_transform(self, X, y=None, **fit_params):
-        """
-        Encoders that utilize the target must make sure that the training data are transformed with:
-            transform(X, y)
-        and not with:
-            transform(X)
-        """
-
-        # the interface requires 'y=None' in the signature but we need 'y'
-        if y is None:
-            raise(TypeError, 'fit_transform() missing argument: ''y''')
-
-        return self.fit(X, y, **fit_params).transform(X, y)
 
     def _train(self, X, y):
         # Initialize the output


### PR DESCRIPTION
# The Error
Calling `fit_transform` for encoders that need target information an incorrect Error was raised:
```python
from category_encoders import *
import pandas as pd
from sklearn.datasets import load_boston
bunch = load_boston()
y = bunch.target
X = pd.DataFrame(bunch.data, columns=bunch.feature_names)
enc = JamesSteinEncoder(cols=['CHAS', 'RAD'])
numeric_dataset = enc.fit_transform(X)
```
Leads to the following error:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-32026f14b053> in <module>
      6 X = pd.DataFrame(bunch.data, columns=bunch.feature_names)
      7 enc = JamesSteinEncoder(cols=['CHAS', 'RAD'])
----> 8 numeric_dataset = enc.fit_transform(X)

~/Documents/Projects/categorical-encoding/category_encoders/james_stein.py in fit_transform(self, X, y, **fit_params)
    320         # the interface requires 'y=None' in the signature but we need 'y'
    321         if y is None:
--> 322             raise(TypeError, 'fit_transform() missing argument: ''y''')
    323 
    324         return self.fit(X, y, **fit_params).transform(X, y)

TypeError: exceptions must derive from BaseException
```
The problem is that we try to `raise` a `tuple` rather than an Error.

# The Solution
The `TypeError` is correctly raised now. Furthermore the code was refactored to use a Mixin (`TransformerWithTargetMixin`) to do this `fit_transform` in order to avoid duplicated code. The `TransformerWithTargetMixin` is similar to the `TransformerMixin` by sklearn, however also calling `transform` with the label `y`. Since both the `TransformerMixin` as well as `TransformerWithTargetMixin` implement only `fit_transform` the `TransformerMixin` is not needed anymore and was removed.   
We now get the correct Error message: 
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-32026f14b053> in <module>
      6 X = pd.DataFrame(bunch.data, columns=bunch.feature_names)
      7 enc = JamesSteinEncoder(cols=['CHAS', 'RAD'])
----> 8 numeric_dataset = enc.fit_transform(X)

~/Documents/Projects/categorical-encoding/category_encoders/utils.py in fit_transform(self, X, y, **fit_params)
    147         """
    148         if y is None:
--> 149             raise TypeError('fit_transform() missing argument: ''y''')
    150         return self.fit(X, y, **fit_params).transform(X, y)

TypeError: fit_transform() missing argument: y
```